### PR TITLE
feat: Update webserver cluster modules and configs

### DIFF
--- a/live/prod/services/webserver-cluster/main.tf
+++ b/live/prod/services/webserver-cluster/main.tf
@@ -11,7 +11,9 @@ provider "aws" {
 
 
 module "webserver_cluster" {
-    source = "github.com/K-dash/terraform-playground-modules//services/webserver-cluster?ref=v0.0.3"
+    source = "github.com/K-dash/terraform-playground-modules//services/webserver-cluster?ref=v0.0.6b"
+
+    server_text = "New Server Text for Prod"
 
     cluster_name = "webservers-prod"
     db_remote_state_bucket = "terraform-state-remote-storage-s3-for-kdash"
@@ -20,27 +22,10 @@ module "webserver_cluster" {
     instance_type = "t2.micro"
     min_size = 2
     max_size = 10
+    enable_auto_scaling = true
+
     custom_tags = {
         Owner = "K-dash"
         DeployedBy = "Terraform"
     }
 }
-
-resource "aws_autoscaling_schedule" "schedule_out_during_business_hours" {
-    scheduled_action_name = "scale_out_during_business_hours"
-    min_size = 2
-    max_size = 10
-    desired_capacity = 10
-    recurrence = "0 9 * * *"
-    autoscaling_group_name = module.webserver_cluster.asg_name
-}
-
-resource "aws_autoscaling_schedule" "scale_in_at_night" {
-    scheduled_action_name = "scale_in_at_night"
-    min_size = 2
-    max_size = 10
-    desired_capacity = 2
-    recurrence = "0 17 * * *"
-    autoscaling_group_name = module.webserver_cluster.asg_name
-}
-

--- a/live/stage/services/webserver-cluster/main.tf
+++ b/live/stage/services/webserver-cluster/main.tf
@@ -10,7 +10,10 @@ provider "aws" {
 }
 
 module "webserver_cluster" {
-    source = "github.com/K-dash/terraform-playground-modules//services/webserver-cluster?ref=v0.0.1"
+    source = "github.com/K-dash/terraform-playground-modules//services/webserver-cluster?ref=v0.0.6b"
+
+    ami = "ami-0fb653ca2d3203ac1"
+    server_text = "foo bar"
 
     cluster_name = "webservers-stage"
     db_remote_state_bucket = "terraform-state-remote-storage-s3-for-kdash"
@@ -19,6 +22,7 @@ module "webserver_cluster" {
     instance_type = "t2.micro"
     min_size = 2
     max_size = 2
+    enable_auto_scaling = false
 }
 
 # moduleのoutputを利用してalbのsecurity_groupにルールを追加


### PR DESCRIPTION
- プロダクション環境とステージング環境の`webserver_cluster`モジュールを`v0.0.6b`へ更新
- プロダクション環境に`server_text`を追加し、テキストを"New Server Text for Prod"に設定
- ステージング環境に`ami`と`server_text`を追加し、テキストを"foo bar"に設定
- オートスケーリングの設定をモジュール側で管理するため、プロダクション環境の手動でのスケジュール設定を削除
- プロダクション環境でオートスケーリングを有効化、ステージング環境で無効化

Branch: feature/update-webserver-cluster