### PR TITLE
feat: Add multi-region MySQL replication setup

### DIFF
--- a/live/prod/data-stores/mysql/main.tf
+++ b/live/prod/data-stores/mysql/main.tf
@@ -1,4 +1,11 @@
 terraform {
+    required_providers {
+        aws = {
+        source  = "hashicorp/aws"
+        version = "~> 5.0"
+        }
+    }
+
     # tfstateファイル格納先のリモートストレージ設定
     backend "s3" {
         key = "prod/data-stores/mysql/terraform.tfstate"
@@ -7,11 +14,41 @@ terraform {
 
 provider "aws" {
     region = "us-east-2"
+    alias = "primary"
 }
 
-module "mysql" {
-    source = "github.com/K-dash/terraform-playground-modules//data-stores/mysql?ref=v0.0.1"
+provider "aws" {
+    region = "us-west-1"
+    alias = "replica"
+}
+
+module "mysql_primary" {
+    source = "github.com/K-dash/terraform-playground-modules//data-stores/mysql?ref=v0.0.10"
+
+    # primaryプロバイダを使用する
+    providers = {
+        aws = aws.primary
+    }
+
     db_password = var.db_password
     db_username = var.db_username
-    instance_type = "db.t3.micro"
+    instance_type = var.instance_type
+    db_name = "prod_mysql_db"
+
+    # レプリケーションを有効化
+    backup_retention_period = 1
+}
+
+module "mysql_replica" {
+    source = "github.com/K-dash/terraform-playground-modules//data-stores/mysql?ref=v0.0.10"
+
+    # replicaプロバイダを使用する
+    providers = {
+        aws = aws.replica
+    }
+    instance_type = var.instance_type
+
+
+    # プライマリのレプリカとして設定
+    replication_source_db = module.mysql_primary.arn
 }

--- a/live/prod/data-stores/mysql/outputs.tf
+++ b/live/prod/data-stores/mysql/outputs.tf
@@ -1,9 +1,31 @@
-output "address" {
-    value = module.mysql.address
-    description = "Connect to the database at this endpoint"
+# primary
+output "primary_address" {
+    value = module.mysql_primary.address
+    description = "Connect to the primary database at this endpoint"
 }
 
-output "port" {
-    value = module.mysql.port
-    description = "The port to access the database on"
+output "primary_port" {
+    value = module.mysql_primary.port
+    description = "The port to access the primary database on"
+}
+
+output "primary_arn" {
+    value = module.mysql_primary.arn
+    description = "The ARN of the primary database"
+}
+
+# replica
+output "replica_address" {
+    value = module.mysql_replica.address
+    description = "Connect to the replica database at this endpoint"
+}
+
+output "replica_port" {
+    value = module.mysql_replica.port
+    description = "The port to access the replica database on"
+}
+
+output "replica_arn" {
+    value = module.mysql_replica.arn
+    description = "The ARN of the replica database"
 }

--- a/live/prod/data-stores/mysql/variables.tf
+++ b/live/prod/data-stores/mysql/variables.tf
@@ -9,3 +9,9 @@ variable "db_password" {
     type = string
     sensitive = true
 }
+
+variable "instance_type" {
+    description = "The type of EC2 Instances to run (e.g. t2.micro)"
+    type = string
+    default = "db.t3.micro"
+}

--- a/live/stage/data-stores/mysql/main.tf
+++ b/live/stage/data-stores/mysql/main.tf
@@ -1,4 +1,11 @@
 terraform {
+    required_providers {
+        aws = {
+        source  = "hashicorp/aws"
+        version = "~> 5.0"
+        }
+    }
+
     # tfstateファイル格納先のリモートストレージ設定
     backend "s3" {
         key = "stage/data-stores/mysql/terraform.tfstate"
@@ -13,5 +20,9 @@ module "mysql" {
     source = "github.com/K-dash/terraform-playground-modules//data-stores/mysql?ref=v0.0.1"
     db_password = var.db_password
     db_username = var.db_username
-    instance_type = "db.t3.micro"
+    instance_type = var.instance_type
+    db_name = "stage_mysql_db"
+
+    # レプリケーションは無効
+    backup_retention_period = 0
 }


### PR DESCRIPTION
- MySQL用Terraform設定ファイルにプロバイダ要件を追加
- マルチリージョンレプリケーションのためのAWSプロバイダエイリアスを設定
- プライマリおよびレプリカモジュールを新規追加し、レプリケーションを構成
- `instance_type`変数を追加し、コードの可読性と柔軟性を向上
- ステージング環境における不要なレプリケーション設定を無効化
- 出力変数を更新し、プライマリおよびレプリカのエンドポイント情報を個別に提供

Branch: multi-region-replication-setup