### PR TITLE
feat: Add support for multi-account setup in Terraform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 TF_VAR_db_username=
 TF_VAR_db_password=
+TF_VAR_child_account_id=

--- a/multi-account/.terraform.lock.hcl
+++ b/multi-account/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.58.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:6vsFc7SmmlElqg3k0X6azrO0yarM7UPCUF4XsAYryjA=",
+    "zh:15e9be54a8febe8e560362b10967cb60b680ca3f78fe207d7209b76e076f59d3",
+    "zh:240f6899a2cec259aa2729ce031f6af2b453f90a8b59118bb2571c54acc65db8",
+    "zh:2b6e8e2ab1a3dce1001503dba6086a128bb2a71652b0d0b3b107db665b7d6881",
+    "zh:579b0ed95247a0bd8bfb3fac7fb767547dde76026c578f4f184b5743af5e32cc",
+    "zh:6adcd10fd12be0be9eb78a89e745a5b77ae0d8b3522cd782456a71178aad8ccb",
+    "zh:7f829cef82f0a02faa97d0fbe1417a40b73fc5142e883b12eebc5b71015efac9",
+    "zh:81977f001998c9096f7b59710996e159774a9313c1bc03db3beb81c3e016ebef",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a5d98ac6fab6e6c85164ca7dd38f94a1e44bd70c0e8354c61f7fbabf698957cd",
+    "zh:c27fa4fed50f6f83ca911bef04f05d635a7b7a01a89dc8fc5d66a277588f08df",
+    "zh:d4042bdf86ca6dc10e0cca91c4fcc592b12572d26185b3d37bbbb9e2026ac68b",
+    "zh:d536482cf4ace0d49a2a86c931150921649beae59337d0c02a785879fe943cf3",
+    "zh:e205f8243274a621fb9ef2b5e2c71e84c1670be1d23697739439f5a831fa620f",
+    "zh:eb76ce0c77fd76c47f57122c91c4fcf0f72c01423538ed7833eaa7eeaae2edf6",
+    "zh:ffe04e494af6cc7348ceb8d85f4c1d5a847a44510827b4496513c810a4d9196d",
+  ]
+}

--- a/multi-account/main.tf
+++ b/multi-account/main.tf
@@ -1,0 +1,35 @@
+terraform {
+    required_providers {
+        aws = {
+        source  = "hashicorp/aws"
+        version = "~> 5.0"
+        }
+    }
+
+    # tfstateファイル格納先のリモートストレージ設定
+    backend "s3" {
+        key = "multi-account/terraform.tfstate"
+    }
+}
+
+provider "aws" {
+    region = "us-east-2"
+    alias = "parent"
+}
+
+provider "aws" {
+    region = "us-east-2"
+    alias = "child"
+
+    assume_role {
+        role_arn = "arn:aws:iam::${var.child_account_id}:role/OrganizationAccountAccessRole"
+    }
+}
+
+module "multi_account_example" {
+    source = "github.com/K-dash/terraform-playground-modules//multi-account?ref=v0.0.12"
+    providers = {
+        aws.parent = aws.parent
+        aws.child  = aws.child
+    }
+}

--- a/multi-account/outputs.tf
+++ b/multi-account/outputs.tf
@@ -1,0 +1,9 @@
+output "parent_account_id" {
+    value       = module.multi_account_example.parent_account_id
+    description = "The ID of the parent AWS account"
+}
+
+output "child_account_id" {
+    value       = module.multi_account_example.child_account_id
+    description = "The ID of the child AWS account"
+}

--- a/multi-account/variables.tf
+++ b/multi-account/variables.tf
@@ -1,0 +1,5 @@
+variable "child_account_id" {
+    description = "The ID of the child AWS account"
+    type        = string
+    default     = ""
+}


### PR DESCRIPTION
multi-accountディレクトリに必要なTerraform設定ファイル(main.tf, outputs.tf, variables.tf)を新規追加し、 .provider設定とモジュールの出力変数を定義しました。.env.exampleにTF_VAR_child_account_idの項目を追加。

branch: feature/multi-account-setup